### PR TITLE
update to latest rust

### DIFF
--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -5,6 +5,7 @@
 // Version 2, as published by Sam Hocevar. See the COPYING file for
 // more details.
 
+
 use osmformat::PrimitiveBlock;
 use osmformat::PrimitiveGroup;
 use groups;

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,7 +7,7 @@
 
 use std::error::Error;
 use std::error::FromError;
-use std::io::IoError;
+use std::old_io::IoError;
 use protobuf;
 
 #[derive(Show)]
@@ -24,14 +24,6 @@ impl Error for OsmPbfError {
             OsmPbfError::Pbf(ref e) => e.description(),
             OsmPbfError::UnsupportedData => "Unsupported data",
             OsmPbfError::InvalidData => "Invalid data",
-        }
-    }
-    fn detail(&self) -> Option<String> {
-        match *self {
-            OsmPbfError::Io(ref e) => e.detail(),
-            OsmPbfError::Pbf(ref e) => e.detail(),
-            OsmPbfError::UnsupportedData => None,
-            OsmPbfError::InvalidData => None,
         }
     }
     fn cause(&self) -> Option<&Error> {

--- a/src/fileformat.rs
+++ b/src/fileformat.rs
@@ -8,7 +8,7 @@
 use protobuf::Message as Message_imported_for_functions;
 use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 
-#[derive(Clone,Default,Show)]
+#[derive(Clone,Default,Debug)]
 pub struct Blob {
     raw: ::protobuf::SingularField<::std::vec::Vec<u8>>,
     raw_size: ::std::option::Option<i32>,
@@ -316,8 +316,8 @@ impl ::protobuf::Message for Blob {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<Blob>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<Blob>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -353,7 +353,7 @@ impl ::std::cmp::PartialEq for Blob {
     }
 }
 
-#[derive(Clone,Default,Show)]
+#[derive(Clone,Default,Debug)]
 pub struct BlobHeader {
     field_type: ::protobuf::SingularField<::std::string::String>,
     indexdata: ::protobuf::SingularField<::std::vec::Vec<u8>>,
@@ -565,8 +565,8 @@ impl ::protobuf::Message for BlobHeader {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<BlobHeader>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<BlobHeader>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ impl<R: Reader> OsmPbfReader<R> {
             Ok(try!(protobuf::parse_from_bytes(blob.get_raw())))
         } else if blob.has_zlib_data() {
             use flate2::reader::ZlibDecoder;
-            let r = std::io::BufReader::new(blob.get_zlib_data());
+            let r = std::old_io::BufReader::new(blob.get_zlib_data());
             let mut zr = ZlibDecoder::new(r);
             Ok(try!(protobuf::parse_from_reader(&mut zr as &mut Reader)))
         } else {
@@ -85,7 +85,7 @@ impl<R: Reader> OsmPbfReader<R> {
     fn next_primitive_block(&mut self)
                             -> Option<Result<osmformat::PrimitiveBlock, OsmPbfError>>
     {
-        use std::io::IoErrorKind;
+        use std::old_io::IoErrorKind;
         if self.finished { return None; }
         let sz = match self.r.read_be_u32() {
             Ok(sz) if sz > 64 * 1024 => return Some(Err(OsmPbfError::InvalidData)),

--- a/src/osmformat.rs
+++ b/src/osmformat.rs
@@ -8,7 +8,7 @@
 use protobuf::Message as Message_imported_for_functions;
 use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 
-#[derive(Clone,Default,Show)]
+#[derive(Clone,Default,Debug)]
 pub struct HeaderBlock {
     bbox: ::protobuf::SingularPtrField<HeaderBBox>,
     required_features: ::protobuf::RepeatedField<::std::string::String>,
@@ -422,8 +422,8 @@ impl ::protobuf::Message for HeaderBlock {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<HeaderBlock>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<HeaderBlock>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -465,7 +465,7 @@ impl ::std::cmp::PartialEq for HeaderBlock {
     }
 }
 
-#[derive(Clone,Default,Show)]
+#[derive(Clone,Default,Debug)]
 pub struct HeaderBBox {
     left: ::std::option::Option<i64>,
     right: ::std::option::Option<i64>,
@@ -683,8 +683,8 @@ impl ::protobuf::Message for HeaderBBox {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<HeaderBBox>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<HeaderBBox>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -718,7 +718,7 @@ impl ::std::cmp::PartialEq for HeaderBBox {
     }
 }
 
-#[derive(Clone,Default,Show)]
+#[derive(Clone,Default,Debug)]
 pub struct PrimitiveBlock {
     stringtable: ::protobuf::SingularPtrField<StringTable>,
     primitivegroup: ::protobuf::RepeatedField<PrimitiveGroup>,
@@ -1017,8 +1017,8 @@ impl ::protobuf::Message for PrimitiveBlock {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<PrimitiveBlock>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<PrimitiveBlock>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1056,7 +1056,7 @@ impl ::std::cmp::PartialEq for PrimitiveBlock {
     }
 }
 
-#[derive(Clone,Default,Show)]
+#[derive(Clone,Default,Debug)]
 pub struct PrimitiveGroup {
     nodes: ::protobuf::RepeatedField<Node>,
     dense: ::protobuf::SingularPtrField<DenseNodes>,
@@ -1333,8 +1333,8 @@ impl ::protobuf::Message for PrimitiveGroup {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<PrimitiveGroup>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<PrimitiveGroup>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1370,7 +1370,7 @@ impl ::std::cmp::PartialEq for PrimitiveGroup {
     }
 }
 
-#[derive(Clone,Default,Show)]
+#[derive(Clone,Default,Debug)]
 pub struct StringTable {
     s: ::protobuf::RepeatedField<::std::vec::Vec<u8>>,
     unknown_fields: ::protobuf::UnknownFields,
@@ -1476,8 +1476,8 @@ impl ::protobuf::Message for StringTable {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<StringTable>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<StringTable>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1505,7 +1505,7 @@ impl ::std::cmp::PartialEq for StringTable {
     }
 }
 
-#[derive(Clone,Default,Show)]
+#[derive(Clone,Default,Debug)]
 pub struct Info {
     version: ::std::option::Option<i32>,
     timestamp: ::std::option::Option<i64>,
@@ -1779,8 +1779,8 @@ impl ::protobuf::Message for Info {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<Info>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<Info>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -1818,7 +1818,7 @@ impl ::std::cmp::PartialEq for Info {
     }
 }
 
-#[derive(Clone,Default,Show)]
+#[derive(Clone,Default,Debug)]
 pub struct DenseInfo {
     version: ::std::vec::Vec<i32>,
     timestamp: ::std::vec::Vec<i64>,
@@ -2134,8 +2134,8 @@ impl ::protobuf::Message for DenseInfo {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<DenseInfo>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<DenseInfo>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -2173,7 +2173,7 @@ impl ::std::cmp::PartialEq for DenseInfo {
     }
 }
 
-#[derive(Clone,Default,Show)]
+#[derive(Clone,Default,Debug)]
 pub struct ChangeSet {
     id: ::std::option::Option<i64>,
     unknown_fields: ::protobuf::UnknownFields,
@@ -2280,8 +2280,8 @@ impl ::protobuf::Message for ChangeSet {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<ChangeSet>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<ChangeSet>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -2309,7 +2309,7 @@ impl ::std::cmp::PartialEq for ChangeSet {
     }
 }
 
-#[derive(Clone,Default,Show)]
+#[derive(Clone,Default,Debug)]
 pub struct Node {
     id: ::std::option::Option<i64>,
     keys: ::std::vec::Vec<u32>,
@@ -2623,8 +2623,8 @@ impl ::protobuf::Message for Node {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<Node>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<Node>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -2662,7 +2662,7 @@ impl ::std::cmp::PartialEq for Node {
     }
 }
 
-#[derive(Clone,Default,Show)]
+#[derive(Clone,Default,Debug)]
 pub struct DenseNodes {
     id: ::std::vec::Vec<i64>,
     denseinfo: ::protobuf::SingularPtrField<DenseInfo>,
@@ -2947,8 +2947,8 @@ impl ::protobuf::Message for DenseNodes {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<DenseNodes>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<DenseNodes>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -2984,7 +2984,7 @@ impl ::std::cmp::PartialEq for DenseNodes {
     }
 }
 
-#[derive(Clone,Default,Show)]
+#[derive(Clone,Default,Debug)]
 pub struct Way {
     id: ::std::option::Option<i64>,
     keys: ::std::vec::Vec<u32>,
@@ -3265,8 +3265,8 @@ impl ::protobuf::Message for Way {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<Way>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<Way>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -3302,7 +3302,7 @@ impl ::std::cmp::PartialEq for Way {
     }
 }
 
-#[derive(Clone,Default,Show)]
+#[derive(Clone,Default,Debug)]
 pub struct Relation {
     id: ::std::option::Option<i64>,
     keys: ::std::vec::Vec<u32>,
@@ -3665,8 +3665,8 @@ impl ::protobuf::Message for Relation {
         &mut self.unknown_fields
     }
 
-    fn type_id(&self) -> ::std::intrinsics::TypeId {
-        ::std::intrinsics::TypeId::of::<Relation>()
+    fn type_id(&self) -> ::std::any::TypeId {
+        ::std::any::TypeId::of::<Relation>()
     }
 
     fn descriptor(&self) -> &'static ::protobuf::reflect::MessageDescriptor {
@@ -3706,7 +3706,7 @@ impl ::std::cmp::PartialEq for Relation {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Show)]
+#[derive(Clone,PartialEq,Eq,Debug)]
 pub enum Relation_MemberType {
     NODE = 0,
     WAY = 1,
@@ -3728,5 +3728,5 @@ impl ::protobuf::ProtobufEnum for Relation_MemberType {
     }
 }
 
-impl ::std::kinds::Copy for Relation_MemberType {
+impl ::std::marker::Copy for Relation_MemberType {
 }


### PR DESCRIPTION
hi,Guillaume

i regenerate two rs files with newest rust-protobuf and make some some updatem but i still get following compile errors, could you please take a look at it ? thanks

src/blocks.rs:19:36: 19:55 error: associated type bindings are not allowed here [E0229]
src/blocks.rs:19 impl<'a> Fn(&'a PrimitiveGroup) -> groups::OsmObjs<'a> for FnOsmObjs<'a> {
                                                    ^~~~~~~~~~~~~~~~~~~
src/blocks.rs:34:36: 34:53 error: associated type bindings are not allowed here [E0229]
src/blocks.rs:34 impl<'a> Fn(&'a PrimitiveGroup) -> groups::Nodes<'a> for FnNodes<'a> {
                                                    ^~~~~~~~~~~~~~~~~
src/blocks.rs:49:36: 49:52 error: associated type bindings are not allowed here [E0229]
src/blocks.rs:49 impl<'a> Fn(&'a PrimitiveGroup) -> groups::Ways<'a> for FnWays<'a> {
                                                    ^~~~~~~~~~~~~~~~
src/blocks.rs:64:36: 64:57 error: associated type bindings are not allowed here [E0229]
src/blocks.rs:64 impl<'a> Fn(&'a PrimitiveGroup) -> groups::Relations<'a> for FnRelations<'a> {
   