### PR TITLE
add contains_key to Tags

### DIFF
--- a/src/objects.rs
+++ b/src/objects.rs
@@ -29,6 +29,10 @@ impl Tags {
     pub fn contains(&self, key: &str, value: &str) -> bool {
         self.0.get(key).map_or(false, |v| v.as_str() == value)
     }
+    /// Returns if contains any value for `key`.
+    pub fn contains_key(&self, key: &str) -> bool {
+        self.0.contains_key(key)
+    }
 }
 impl Deref for Tags {
     type Target = TagsImpl;


### PR DESCRIPTION
This PR exposes the functionality to query whether a tag is present. I found this useful for the `get_objs_and_deps` method, where you may not be interested in any one particular tag, but rather the presence of any. For example, `http://wiki.openstreetmap.org/wiki/Key:building` has many different values where checking each explicitly could be tedious.