### PR TITLE
Add serde serialization to objects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ appveyor = { repository = "TeXitoi/osmpbfreader-rs" }
 flate2 = "0.2.17"
 byteorder = "1.0"
 protobuf = "1.1"
-flat_map = "0.0.4"
+flat_map = "0.0.7"
 rental = "0.4"
 par-map = "0.1"
 pub-iterator-type = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ appveyor = { repository = "TeXitoi/osmpbfreader-rs" }
 flate2 = "0.2.17"
 byteorder = "1.0"
 protobuf = "1.1"
-flat_map = "0.0.7"
+flat_map = { version = "0.0.7", git = "https://github.com/antoine-de/flat_map", branch = "serialization" }
 rental = "0.4"
 par-map = "0.1"
 pub-iterator-type = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ appveyor = { repository = "TeXitoi/osmpbfreader-rs" }
 flate2 = "0.2.17"
 byteorder = "1.0"
 protobuf = "1.1"
-flat_map = { version = "0.0.7", git = "https://github.com/antoine-de/flat_map", branch = "serialization", features = ["serde1"] }
+flat_map = { version = "0.0.7", features = ["serde1"] }
 rental = "0.4"
 par-map = "0.1"
 pub-iterator-type = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,12 @@ appveyor = { repository = "TeXitoi/osmpbfreader-rs" }
 flate2 = "0.2.17"
 byteorder = "1.0"
 protobuf = "1.1"
-flat_map = { version = "0.0.7", git = "https://github.com/antoine-de/flat_map", branch = "serialization" }
+flat_map = { version = "0.0.7", git = "https://github.com/antoine-de/flat_map", branch = "serialization", features = ["serde1"] }
 rental = "0.4"
 par-map = "0.1"
 pub-iterator-type = "0.1"
+serde = "1.0"
+serde_derive = "1.0"
 
 [dev-dependencies]
 log = "0.3.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,9 @@ extern crate rental;
 extern crate par_map;
 #[macro_use]
 extern crate pub_iterator_type;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
 
 pub use objects::*;
 pub use error::Error;

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -16,7 +16,7 @@ use std::iter::FromIterator;
 /// [OpenStreetMap wiki page about
 /// tags](http://wiki.openstreetmap.org/wiki/Tags) for more
 /// information.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct Tags(TagsImpl);
 /// FlatMap representing the key-value pairs of the tags
 pub type TagsImpl = ::flat_map::FlatMap<String, String>;
@@ -48,19 +48,19 @@ impl FromIterator<(String, String)> for Tags {
 }
 
 /// A node identifier
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Copy)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Copy, Serialize, Deserialize)]
 pub struct NodeId(pub i64);
 
 /// A way identifier
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Copy)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Copy, Serialize, Deserialize)]
 pub struct WayId(pub i64);
 
 /// A relation identifier
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Copy)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Copy, Serialize, Deserialize)]
 pub struct RelationId(pub i64);
 
 /// An OpenStreetMap object identifier
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Copy)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Copy, Serialize, Deserialize)]
 pub enum OsmId {
     /// The identifier of a node
     Node(NodeId),
@@ -106,7 +106,7 @@ impl OsmId {
 }
 
 /// An OpenStreetMap object.
-#[derive(Debug, PartialEq, PartialOrd, Clone)]
+#[derive(Debug, PartialEq, PartialOrd, Clone, Serialize, Deserialize)]
 pub enum OsmObj {
     /// A node
     Node(Node),
@@ -170,7 +170,7 @@ impl OsmObj {
 /// An OpenStreetMap node.  See the [OpenStreetMap wiki page about
 /// node](http://wiki.openstreetmap.org/wiki/Node) for more
 /// information.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Serialize, Deserialize)]
 pub struct Node {
     /// The id of the node.
     pub id: NodeId,
@@ -195,7 +195,7 @@ impl Node {
 /// An OpenStreetMap way.  See the [OpenStreetMap wiki page about
 /// way](http://wiki.openstreetmap.org/wiki/Way) for more
 /// information.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Serialize, Deserialize)]
 pub struct Way {
     /// The id of the way.
     pub id: WayId,
@@ -218,7 +218,7 @@ impl Way {
 }
 
 /// A reference to an object with a role.  Used in the relation object.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Serialize, Deserialize)]
 pub struct Ref {
     /// Id of the member.
     pub member: OsmId,
@@ -229,7 +229,7 @@ pub struct Ref {
 /// An OpenStreetMap relation.  See the [OpenStreetMap wiki page about
 /// relation](http://wiki.openstreetmap.org/wiki/Relation) for more
 /// information.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Serialize, Deserialize)]
 pub struct Relation {
     /// The id of the relation.
     pub id: RelationId,


### PR DESCRIPTION
This PR makes all the osmpbfreader objects serialisable with serde.

Note: I don't think this PR should be merged is as (it's just for review for the moment) because it depends on a custom `flat_map` fork (https://github.com/toffaletti/flat_map/pull/8) for a nice flat_map serialization

the old flat_map serialization would be enough but unfortunately `flat_map`'s `serde1` feature needs a rust nightly version (it has been corrected in my PR)

So I think we should wait for the flat_map PR to be merged (and after change the Cargo.toml)