### PR TITLE
More threading options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,5 @@ matrix:
 script:
 - cargo build --verbose
 - cargo test --verbose
+- cargo test --verbose --no-default-features
+- cargo test --verbose --no-default-features --features="rayon"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "osmpbfreader"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Guillaume Pinot <texitoi@texitoi.eu>"]
 description = "Read OpenStreetMap PBF files in rust."
 documentation = "https://docs.rs/osmpbfreader"
@@ -20,10 +20,20 @@ byteorder = "1.0"
 protobuf = "2"
 flat_map = { version = "0.0.7", features = ["serde1"] }
 rental = "0.4"
-par-map = "0.1"
 pub-iterator-type = "0.1"
 serde = "1.0"
 serde_derive = "1.0"
+
+[dependencies.par-map]
+version = "0.1"
+optional = true
+
+[dependencies.rayon]
+version = "1.0"
+optional = true
+
+[features]
+default = ["par-map"]
 
 [dev-dependencies]
 log = "0.3.6"

--- a/examples/count.rs
+++ b/examples/count.rs
@@ -20,7 +20,14 @@ fn count<F: Fn(&osmpbfreader::Tags) -> bool>(filter: F, filename: &std::ffi::OsS
     let mut nb_way_nodes = 0;
     let mut nb_rels = 0;
     let mut nb_rel_refs = 0;
-    for obj in pbf.par_iter().map(Result::unwrap) {
+
+    let iter;
+    #[cfg(feature="par-map")]
+    { iter = pbf.par_iter() }
+    #[cfg(not(feature="par-map"))]
+    { iter = pbf.iter() }
+
+    for obj in iter.map(Result::unwrap) {
         if !filter(obj.tags()) {
             continue;
         }

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -13,7 +13,7 @@ use osmformat::PrimitiveBlock;
 
 pub_iterator_type! {
     #[doc="Iterator on the `OsmObj` of a `PrimitiveBlock`."]
-    OsmObjs['a] = Box<Iterator<Item = OsmObj> + 'a>
+    OsmObjs['a] = Box<Iterator<Item = OsmObj> + Send + 'a>
 }
 
 pub fn iter(block: &PrimitiveBlock) -> OsmObjs {
@@ -23,7 +23,7 @@ pub fn iter(block: &PrimitiveBlock) -> OsmObjs {
 
 pub_iterator_type! {
     #[doc="Iterator on the `Node` of a `PrimitiveBlock`."]
-    Nodes['a] = Box<Iterator<Item = Node> + 'a>
+    Nodes['a] = Box<Iterator<Item = Node> + Send + 'a>
 }
 
 pub fn nodes(block: &PrimitiveBlock) -> Nodes {
@@ -43,7 +43,7 @@ pub fn ways(block: &PrimitiveBlock) -> Ways {
 
 pub_iterator_type! {
     #[doc="Iterator on the `Relation` of a `PrimitiveBlock`."]
-    Relations['a] = Box<Iterator<Item = Relation> + 'a>
+    Relations['a] = Box<Iterator<Item = Relation> + Send + 'a>
 }
 
 pub fn relations(block: &PrimitiveBlock) -> Relations {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,8 @@
 //! decoded in parallel.
 //!
 //! ```rust
+//! # #[cfg(feature="par-map")]
+//! # {
 //! use std::process::exit;
 //! let mut pbf = osmpbfreader::OsmPbfReader::new(std::io::empty());
 //! for obj in pbf.par_iter() {
@@ -56,6 +58,7 @@
 //!
 //!     println!("{:?}", obj);
 //! }
+//! # }
 //! ```
 //!
 //! # Into the details
@@ -99,12 +102,15 @@ extern crate flate2;
 extern crate protobuf;
 #[macro_use]
 extern crate rental;
-extern crate par_map;
 #[macro_use]
 extern crate pub_iterator_type;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
+#[cfg(feature="par-map")]
+extern crate par_map;
+#[cfg(feature="rayon")]
+extern crate rayon;
 
 pub use error::Error;
 pub use error::Result;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -51,6 +51,12 @@ impl<R: io::Read> OsmPbfReader<R> {
         Iter(self.blobs().flat_map(result_blob_into_iter))
     }
 
+    /// Returns a parallel iterator on the OsmObj of the pbf file, using the
+    /// specified number of threads. See `par_iter`.
+    pub fn par_iter_with_nb_threads<'a>(&'a mut self, nb: usize) -> ParIter<'a, R> {
+        ParIter(self.blobs().with_nb_threads(nb).par_flat_map(result_blob_into_iter))
+    }
+
     /// Returns a parallel iterator on the OsmObj of the pbf file.
     ///
     /// Several threads decode in parallel the file.  The memory and
@@ -66,13 +72,7 @@ impl<R: io::Read> OsmPbfReader<R> {
     /// }
     /// ```
     pub fn par_iter<'a>(&'a mut self) -> ParIter<'a, R> {
-        use std::env;
-
-        let blobs = self.blobs();
-        ParIter(match env::var("PBF_ITER_THREADS").ok().and_then(|v| v.parse().ok()) {
-            Some(nb) => blobs.with_nb_threads(nb).par_flat_map(result_blob_into_iter),
-            None => blobs.par_flat_map(result_blob_into_iter),
-        })
+       ParIter(self.blobs().par_flat_map(result_blob_into_iter))
     }
 
     /// Rewinds the pbf file to the begining.


### PR DESCRIPTION
This PR:
- Makes `par-map` a default optional dependency.
- Adds `rayon` as a non-default optional dependency.
- Adds `rayon_iter` to `OsmPbfReader` for iterating over `OsmObj`s.
- Adds `par_iter_with_nb_threads` to `OsmPbfReader`  in order to provide an explicit thread-count when using `par-map`.

The reasons for adding optional `rayon` integration are:
- It makes it easy for users of this  crate to read *and process*  `OsmObjs`s in parallel.
- It grants greater control over  thread configuration through `rayon`'s shared thread pool.
- It eliminates dependencies if the user is already importing `rayon` but not `par-map`.