### PR TITLE
Asref

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "osmpbfreader"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Guillaume Pinot <texitoi@texitoi.eu>"]
 description = "Read OpenStreetMap PBF files in rust."
 documentation = "https://docs.rs/osmpbfreader"


### PR DESCRIPTION
The idea behind it is to make usage of non-copy type more flexible (I'm thinking about `osm_boundaries_utils` when saying this).

It'll allow to make minimal changes without having to break everything.