### PR TITLE
Added smartstring feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,10 @@ par-map = "0.1"
 pub-iterator-type = "0.1"
 serde = "1.0"
 serde_derive = "1.0"
+smartstring = { version = "0.2", features = ["serde"], optional = true }
+
+[features]
+smartstrings = ["smartstring"]
 
 [dev-dependencies]
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,7 @@ par-map = "0.1"
 pub-iterator-type = "0.1"
 serde = "1.0"
 serde_derive = "1.0"
-smartstring = { version = "0.2", features = ["serde"], optional = true }
-
-[features]
-smartstrings = ["smartstring"]
+smartstring = { version = "0.2", features = ["serde"] }
 
 [dev-dependencies]
 log = "0.4"

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -8,6 +8,9 @@
 use objects::*;
 use osmformat;
 use osmformat::{PrimitiveBlock, PrimitiveGroup};
+#[cfg(feature = "smartstring")]
+use smartstring::alias::String;
+use std::borrow::Cow;
 use std::convert::From;
 use std::iter::Chain;
 use std::iter::Map;
@@ -206,7 +209,11 @@ impl<'a> Iterator for Relations<'a> {
 }
 
 fn make_string(k: usize, block: &osmformat::PrimitiveBlock) -> String {
-    String::from_utf8_lossy(&*block.get_stringtable().get_s()[k]).into_owned()
+    let cow = std::string::String::from_utf8_lossy(&*block.get_stringtable().get_s()[k]);
+    match cow {
+        Cow::Borrowed(s) => String::from(s),
+        Cow::Owned(s) => String::from(s),
+    }
 }
 
 fn make_lat(c: i64, b: &osmformat::PrimitiveBlock) -> i32 {

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -8,7 +8,6 @@
 use objects::*;
 use osmformat;
 use osmformat::{PrimitiveBlock, PrimitiveGroup};
-#[cfg(feature = "smartstring")]
 use smartstring::alias::String;
 use std::borrow::Cow;
 use std::convert::From;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,10 @@
 //! }
 //! ```
 //!
+//! # Smart Strings
+//!
+//! By enabling the `smartstrings` feature, the type `std::str::String` for OSM tags is replaced by `smartstring::alias::String`. [smartstring](https://crates.io/crates/smartstring) is a crate which avoids heap allocation for small-ish strings (23 bytes on 64 bit architectures), but otherwise behaves like a normal `String` type. Most of OSM tags fit match this criteria, so this can yield substantial improvements for performance and memory usage.
+//!
 //! # Into the details
 //!
 //! This crate is build around basic iterators on different parts of
@@ -105,6 +109,8 @@ extern crate pub_iterator_type;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
+#[cfg(feature = "smartstrings")]
+extern crate smartstring;
 
 pub use error::Error;
 pub use error::Result;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,10 +58,6 @@
 //! }
 //! ```
 //!
-//! # Smart Strings
-//!
-//! By enabling the `smartstrings` feature, the type `std::str::String` for OSM tags is replaced by `smartstring::alias::String`. [smartstring](https://crates.io/crates/smartstring) is a crate which avoids heap allocation for small-ish strings (23 bytes on 64 bit architectures), but otherwise behaves like a normal `String` type. Most of OSM tags fit match this criteria, so this can yield substantial improvements for performance and memory usage.
-//!
 //! # Into the details
 //!
 //! This crate is build around basic iterators on different parts of
@@ -94,6 +90,8 @@
 //! Notice that `primitive_block_from_blob` can be costy as it
 //! uncompress the blob.  Using some kind of parallel map can then
 //! improve the reading speed of the PBF file.
+//!
+//! OSM tags are stored as key/value maps of type `smartstring::alias::String`. [smartstring](https://crates.io/crates/smartstring) is a crate which re-implements the `std::str::String` API, while avoiding heap allocation for short strings (up to 23 bytes on 64 bit architectures). Longer strings are allocated transparently. Most OSM tags keys & values are rather short, so using this type can yield substantial improvements for performance and memory usage.
 
 #![deny(missing_docs)]
 
@@ -109,7 +107,6 @@ extern crate pub_iterator_type;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
-#[cfg(feature = "smartstrings")]
 extern crate smartstring;
 
 pub use error::Error;

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -9,6 +9,8 @@
 //!
 //! There are 3 types of objects: nodes, ways and relations.
 
+#[cfg(feature = "smartstring")]
+use smartstring::alias::String;
 use std::iter::FromIterator;
 use std::ops::{Deref, DerefMut};
 

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -9,7 +9,6 @@
 //!
 //! There are 3 types of objects: nodes, ways and relations.
 
-#[cfg(feature = "smartstring")]
 use smartstring::alias::String;
 use std::iter::FromIterator;
 use std::ops::{Deref, DerefMut};


### PR DESCRIPTION
Hi there,

after reading https://fasterthanli.me/articles/small-strings-in-rust I tried out [smartstring](https://crates.io/crates/smartstring) in an osm processing pipeline (it's quite unintrusive) and the performance gain for my usecase (lots of tag comparisons) was rather impressive (almost 50%). Does it makes sense to add it as a feature to this library?