### PR TITLE
Replace rental with self_cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,13 @@ travis-ci = { repository = "TeXitoi/osmpbfreader-rs" }
 appveyor = { repository = "TeXitoi/osmpbfreader-rs" }
 
 [dependencies]
-flate2 = "1.0"
 byteorder = "1.3"
-protobuf = "2"
 flat_map = { version = "0.0.9", features = ["serde1"] }
-rental = "0.5"
+flate2 = "1.0"
 par-map = "0.1"
+protobuf = "2"
 pub-iterator-type = "0.1"
+self_cell = "0.8.0"
 serde = "1.0"
 serde_derive = "1.0"
 smartstring = { version = "0.2", features = ["serde"] }

--- a/src/blobs.rs
+++ b/src/blobs.rs
@@ -34,14 +34,14 @@ impl<'a> Iterator for OsmBlobObjs {
 }
 
 /// An iterator on `Result<OsmObj>`.
-pub struct OsmObjsIter(OsmObjsImpl);
+pub struct OsmObjs(OsmObjsImpl);
 
 enum OsmObjsImpl {
     OkIter(iter::Map<OsmBlobObjs, fn(OsmObj) -> Result<OsmObj>>),
     ErrIter(iter::Once<Result<OsmObj>>),
 }
 
-impl Iterator for OsmObjsIter {
+impl Iterator for OsmObjs {
     type Item = Result<OsmObj>;
     fn next(&mut self) -> Option<Self::Item> {
         match self.0 {
@@ -52,10 +52,10 @@ impl Iterator for OsmObjsIter {
 }
 
 /// Transforms a `Result<blob>` into a `Iterator<Item = Result<OsmObj>>`.
-pub fn result_blob_into_iter(result: Result<Blob>) -> OsmObjsIter {
+pub fn result_blob_into_iter(result: Result<Blob>) -> OsmObjs {
     match result.and_then(|b| ::reader::primitive_block_from_blob(&b)) {
-        Ok(block) => OsmObjsIter(OsmObjsImpl::OkIter(new_rent_osm_objs(block).map(Ok))),
-        Err(e) => OsmObjsIter(OsmObjsImpl::ErrIter(iter::once(Err(e)))),
+        Ok(block) => OsmObjs(OsmObjsImpl::OkIter(new_rent_osm_objs(block).map(Ok))),
+        Err(e) => OsmObjs(OsmObjsImpl::ErrIter(iter::once(Err(e)))),
     }
 }
 

--- a/src/blobs.rs
+++ b/src/blobs.rs
@@ -9,6 +9,7 @@
 
 use std::iter;
 
+use crate::blocks;
 use crate::blocks::OsmObjs as OsmBlockObjs;
 use crate::fileformat::Blob;
 use crate::objects::OsmObj;
@@ -60,6 +61,5 @@ pub fn result_blob_into_iter(result: Result<Blob>) -> OsmObjs {
 }
 
 fn new_rent_osm_objs(block: PrimitiveBlock) -> OsmBlobObjs {
-    // blocks::iter
-    OsmBlobObjs::from_fn(block, |block| panic!())
+    OsmBlobObjs::from_fn(block, |block| blocks::iter(block))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,12 +98,12 @@
 extern crate byteorder;
 extern crate flat_map;
 extern crate flate2;
+extern crate par_map;
 extern crate protobuf;
 #[macro_use]
-extern crate rental;
-extern crate par_map;
-#[macro_use]
 extern crate pub_iterator_type;
+#[macro_use]
+extern crate self_cell;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -282,14 +282,14 @@ pub fn primitive_block_from_blob(blob: &Blob) -> Result<PrimitiveBlock> {
 
 pub_iterator_type! {
     #[doc="Iterator on the `OsmObj` of the pbf file."]
-    Iter['a, R] = iter::FlatMap<Blobs<'a, R>, blobs::OsmObjs, fn(Result<Blob>) -> blobs::OsmObjs>
+    Iter['a, R] = iter::FlatMap<Blobs<'a, R>, blobs::OsmObjsIter, fn(Result<Blob>) -> blobs::OsmObjsIter>
     where R: io::Read + 'a
 }
 
 pub_iterator_type! {
     #[doc="Parallel iterator on the `OsmObj` of the pbf file."]
     ParIter['a, R] = par_map::FlatMap<Blobs<'a, R>,
-                                      blobs::OsmObjs,
-                                      fn(Result<Blob>) -> blobs::OsmObjs>
+                                      blobs::OsmObjsIter,
+                                      fn(Result<Blob>) -> blobs::OsmObjsIter>
     where R: io::Read + 'a
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -282,14 +282,14 @@ pub fn primitive_block_from_blob(blob: &Blob) -> Result<PrimitiveBlock> {
 
 pub_iterator_type! {
     #[doc="Iterator on the `OsmObj` of the pbf file."]
-    Iter['a, R] = iter::FlatMap<Blobs<'a, R>, blobs::OsmObjsIter, fn(Result<Blob>) -> blobs::OsmObjsIter>
+    Iter['a, R] = iter::FlatMap<Blobs<'a, R>, blobs::OsmObjs, fn(Result<Blob>) -> blobs::OsmObjs>
     where R: io::Read + 'a
 }
 
 pub_iterator_type! {
     #[doc="Parallel iterator on the `OsmObj` of the pbf file."]
     ParIter['a, R] = par_map::FlatMap<Blobs<'a, R>,
-                                      blobs::OsmObjsIter,
-                                      fn(Result<Blob>) -> blobs::OsmObjsIter>
+                                      blobs::OsmObjs,
+                                      fn(Result<Blob>) -> blobs::OsmObjs>
     where R: io::Read + 'a
 }


### PR DESCRIPTION
Before:

$ cargo build
... 47 dependencies
Finished dev [unoptimized + debuginfo] target(s) in 48.40s

After:

$ cargo build
... 45 dependencies
Finished dev [unoptimized + debuginfo] target(s) in 35.24s

That's 37% faster in this very rough test. But the fewer dependencies make this seem plausible, especially since compiling rental is expensive.

There are still some proc macro dependencies like syn left, but they have nothing to do with `self_cell` as it has 0 dependencies and doesn't use proc macros.

Disclaimer I'm the author of `self_cell`.

I ran `cargo test` and all tests passed before and after.

Note, rental is no longer maintained and ouroboros still carries the compile time cost of proc macros. Plus https://github.com/scpwiki/wikijump/pull/270#pullrequestreview-655216432 here they noticed a perf boost over ouroboros, I'd greatly appreciate if you could benchmark before and after and report your findings here.