### PR TITLE
update self_cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ flate2 = "1.0"
 par-map = "0.1"
 protobuf = "2"
 pub-iterator-type = "0.1"
-self_cell = "0.9.0" 
+self_cell = "0.10.0" 
 serde = { version = "1.0", features = ["derive"] }
 smartstring = { version = "0.2", features = ["serde"] }
 


### PR DESCRIPTION
if I use `osmpbfreader` in another repo i get the following error:
```
error: failed to select a version for the requirement `self_cell = "^0.9.0"`
candidate versions found which didn't match: 0.10.0
location searched: crates.io index
required by package `osmpbfreader v0.15.0`
```
I expect to fix this by upgrading `self_cell`