### PR TITLE
objects.rs: add an `into_inner` method to allow moving out values

### DIFF
--- a/src/objects.rs
+++ b/src/objects.rs
@@ -26,9 +26,15 @@ impl Tags {
     pub fn new() -> Tags {
         Tags(::flat_map::FlatMap::new())
     }
+
     /// Returns if it contains a tag with the given `key` and `value`.
     pub fn contains(&self, key: &str, value: &str) -> bool {
         self.0.get(key).map_or(false, |v| v.as_str() == value)
+    }
+
+    /// Consume tags into inner FlatMap representation
+    pub fn into_inner(self) -> ::flat_map::FlatMap<String, String> {
+        self.0
     }
 }
 


### PR DESCRIPTION
It seems there is currently no way of moving out values from `Tags`, so all strings (actually smartstring) will need to be copied at some point, even when the structure could be consumed.

I think a reasonable way to provide this is to implement the same `into_inner` as `flatmap` does, which allows to take ownership of the whole internal `Vec`.