### PR TITLE
reader.rs add `get_objs_and_deps_on_the_fly`

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -392,6 +392,13 @@ impl<R: io::Read> OsmPbfReader<R> {
                 }
             }
 
+            // If there are no more objects that are pending, then we don't need reading the file
+            // anymore. THis will typically only happen with the full planet dataset because
+            // geofabrik export ofen cut ways and relations at the border.
+            if pending.is_empty() {
+                break;
+            }
+
             import_first_layer = false;
         }
     }


### PR DESCRIPTION
This is a suggestion for a new way of fetching objects that differs slightly from `get_obj_and_deps`. I think I could be helpful to other so I'm putting it here, but one could argue it is too specific.

The idea is to provide an API similar to `get_obj_and_deps` but that doesn't require to hold all returned objects in memory. For example if a node is filtered in, it can be immediately processed without waiting for other objects (given it is not a member of another object).

Here it is implemented by taking a callback function as argument, but if you think it could be interesting to include in the library, maybe returning an iterator would be more convenient (although it might make the API a bit more complicated).


### Motivations

Initially, we were using `get_objs_and_deps_store` to load all addresses from OSM (planet). As it requires a consequent amount of memory, the store was backed by a SQLite database. However as we are moving our CI to a k8s cluster, available PVC's don't provide fast enough random I/Os to use the SQLite backend anymore. This new solution proved to be a good way to fit the computation into memory and improved performance consequently in our case.

### Improvements ideas

 - as I said this could be turned into an iterator API
 - I'm quite surprised `BTreeMap` offers such good performances, hashmaps are usually the recommended default as they work better with caching mechanisms, but I didn't notice any improvement while experimenting with `fxhash` (using std HashMap but with a more straightforward hashing algorithm) even though flamegraph appears to show that about 25% of time is spent on maps lookups (on main thread).