### PR TITLE
avoid crash by upgrading smartstring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,9 @@ flate2 = "1.0"
 par-map = "0.1"
 protobuf = "2"
 pub-iterator-type = "0.1"
-self_cell = "0.10.0" 
+self_cell = "0.10.0"
 serde = { version = "1.0", features = ["derive"] }
-smartstring = { version = "0.2", features = ["serde"] }
+smartstring = { version = "1.0.1", features = ["serde"] }
 
 [dev-dependencies]
 log = "0.4"


### PR DESCRIPTION
`smartstring` 0.2 includes undefined behaviour which resulted in crashes on my machine.
Upgrading to 1.0.1 fixes this and appears to require no further actions than changing version.
(also removed a trailing space)
