### PR TITLE
feat: Make serde serialization and deserialization optional via `serde` feature

### DIFF
--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -24,3 +24,6 @@ jobs:
 
       - name: Run tests
         run: cargo test
+
+      - name: Run tests with optional features
+        run: cargo test --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "osmpbfreader"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Guillaume Pinot <texitoi@texitoi.eu>"]
 description = "Read OpenStreetMap PBF files in rust."
 documentation = "https://docs.rs/osmpbfreader"
@@ -11,16 +11,20 @@ license = "WTFPL"
 readme = "README.md"
 edition = "2021"
 
+[features]
+# Enables serde serialization/deserialization for all OpenStreetMap data structures
+serde = ["dep:serde", "flat_map/serde1", "smartstring/serde"]
+
 [dependencies]
 byteorder = "1.3"
-flat_map = { version = "0.0.10", features = ["serde1"] }
+flat_map = "0.0.10"
 flate2 = "1.0"
 par-map = "0.1"
 protobuf = "3"
 pub-iterator-type = "0.1"
 self_cell = "1.0.2"
-serde = { version = "1.0", features = ["derive"] }
-smartstring = { version = "1.0.1", features = ["serde"] }
+serde = { version = "1.0", features = ["derive"], optional = true }
+smartstring = "1.0.1"
 
 [dev-dependencies]
 log = "0.4"

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -9,6 +9,7 @@
 //!
 //! There are 3 types of objects: nodes, ways and relations.
 
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use smartstring::alias::String;
 use std::iter::FromIterator;
@@ -18,7 +19,8 @@ use std::ops::{Deref, DerefMut};
 /// [OpenStreetMap wiki page about
 /// tags](http://wiki.openstreetmap.org/wiki/Tags) for more
 /// information.
-#[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Tags(::flat_map::FlatMap<String, String>);
 
 impl Tags {
@@ -59,19 +61,23 @@ impl FromIterator<(String, String)> for Tags {
 }
 
 /// A node identifier
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Copy, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct NodeId(pub i64);
 
 /// A way identifier
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Copy, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct WayId(pub i64);
 
 /// A relation identifier
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Copy, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct RelationId(pub i64);
 
 /// An OpenStreetMap object identifier
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Copy, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum OsmId {
     /// The identifier of a node
     Node(NodeId),
@@ -126,7 +132,8 @@ impl OsmId {
 }
 
 /// An OpenStreetMap object.
-#[derive(Debug, PartialEq, PartialOrd, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, PartialOrd, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum OsmObj {
     /// A node
     Node(Node),
@@ -191,7 +198,8 @@ impl OsmObj {
 /// An OpenStreetMap node.  See the [OpenStreetMap wiki page about
 /// node](http://wiki.openstreetmap.org/wiki/Node) for more
 /// information.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Node {
     /// The id of the node.
     pub id: NodeId,
@@ -217,7 +225,8 @@ impl Node {
 /// An OpenStreetMap way.  See the [OpenStreetMap wiki page about
 /// way](http://wiki.openstreetmap.org/wiki/Way) for more
 /// information.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Way {
     /// The id of the way.
     pub id: WayId,
@@ -241,7 +250,8 @@ impl Way {
 }
 
 /// A reference to an object with a role.  Used in the relation object.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Ref {
     /// Id of the member.
     pub member: OsmId,
@@ -252,7 +262,8 @@ pub struct Ref {
 /// An OpenStreetMap relation.  See the [OpenStreetMap wiki page about
 /// relation](http://wiki.openstreetmap.org/wiki/Relation) for more
 /// information.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Relation {
     /// The id of the relation.
     pub id: RelationId,


### PR DESCRIPTION
This PR disables serde serialization and deserialization for OSM objects by default, reducing compiled binary size from 1.3MB to 1.1 MB and improving compilation times.
This serialization and deserialization (`#[derive(Serialize, Deserialize)]`) can be enabled via `serde` feature by either:

- `cargo add osmpbfreader -F serde`
- `osmpbfreader = { version = "0.19", features = ["serde"]}` in `Cargo.toml`