### PR TITLE
ci: Use GitHub Actions for CI

### DIFF
--- a/.github/workflows/sanity_checks.yml
+++ b/.github/workflows/sanity_checks.yml
@@ -1,0 +1,26 @@
+name: Sanity Checks
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt, clippy
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run Clippy
+        run: cargo clippy -- -Dwarnings
+
+      - name: Run tests
+        run: cargo test

--- a/examples/count.rs
+++ b/examples/count.rs
@@ -11,7 +11,7 @@ extern crate env_logger;
 extern crate osmpbfreader;
 
 fn count<F: Fn(&osmpbfreader::Tags) -> bool>(filter: F, filename: &std::ffi::OsStr) {
-    let r = std::fs::File::open(&std::path::Path::new(filename)).unwrap();
+    let r = std::fs::File::open(std::path::Path::new(filename)).unwrap();
     let mut pbf = osmpbfreader::OsmPbfReader::new(r);
     let mut nb_nodes = 0;
     let mut sum_lon = 0.;

--- a/examples/count_with_deps.rs
+++ b/examples/count_with_deps.rs
@@ -11,7 +11,7 @@ extern crate env_logger;
 extern crate osmpbfreader;
 
 fn count<F: Fn(&osmpbfreader::Tags) -> bool>(filter: F, filename: &std::ffi::OsStr) {
-    let r = std::fs::File::open(&std::path::Path::new(filename)).unwrap();
+    let r = std::fs::File::open(std::path::Path::new(filename)).unwrap();
     let mut pbf = osmpbfreader::OsmPbfReader::new(r);
     let objs = pbf.get_objs_and_deps(|obj| filter(obj.tags())).unwrap();
     let mut nb_nodes = 0;

--- a/examples/relation.rs
+++ b/examples/relation.rs
@@ -14,7 +14,7 @@ fn wanted(obj: &osmpbfreader::OsmObj) -> bool {
 fn main() {
     let filename = std::env::args_os().nth(1).unwrap();
     let path = std::path::Path::new(&filename);
-    let r = std::fs::File::open(&path).unwrap();
+    let r = std::fs::File::open(path).unwrap();
     let mut pbf = osmpbfreader::OsmPbfReader::new(r);
     let objects = pbf.get_objs_and_deps(wanted).unwrap();
     println!(

--- a/examples/tutorial.rs
+++ b/examples/tutorial.rs
@@ -10,7 +10,7 @@ extern crate osmpbfreader;
 fn main() {
     let filename = std::env::args_os().nth(1).unwrap();
     let path = std::path::Path::new(&filename);
-    let r = std::fs::File::open(&path).unwrap();
+    let r = std::fs::File::open(path).unwrap();
     let mut pbf = osmpbfreader::OsmPbfReader::new(r);
     let mut nb = 0;
     for _obj in pbf.iter().map(Result::unwrap) {

--- a/src/blobs.rs
+++ b/src/blobs.rs
@@ -47,6 +47,7 @@ wrap!(OsmBlobNodes, BlockNodes => super::Node);
 /// An iterator on `Result<OsmObj>`.
 pub struct OsmObjs<T: Iterator>(OsmObjsImpl<T>);
 
+#[allow(clippy::type_complexity)]
 enum OsmObjsImpl<T: Iterator> {
     OkIter(iter::Map<T, fn(<T as Iterator>::Item) -> crate::Result<<T as Iterator>::Item>>),
     ErrIter(iter::Once<crate::Result<<T as Iterator>::Item>>),

--- a/src/blobs.rs
+++ b/src/blobs.rs
@@ -9,31 +9,33 @@
 
 use std::iter;
 
-use crate::blocks::{self, OsmObjs as OsmBlockObjs, Relations as BlockRelations, Ways as BlockWays, Nodes as BlockNodes};
+use crate::blocks::{
+    self, Nodes as BlockNodes, OsmObjs as OsmBlockObjs, Relations as BlockRelations,
+    Ways as BlockWays,
+};
 use crate::fileformat::Blob;
 use crate::objects::OsmObj;
 use crate::osmformat::PrimitiveBlock;
 
 macro_rules! wrap {
     ($name: ident, $wrap_type: ident => $inner_type: path) => {
-self_cell::self_cell!(
-    #[allow(missing_docs)]
-    pub struct $name {
-        owner: PrimitiveBlock,
+        self_cell::self_cell!(
+            #[allow(missing_docs)]
+            pub struct $name {
+                owner: PrimitiveBlock,
 
-        #[covariant]
-        dependent: $wrap_type,
-    }
-);
+                #[covariant]
+                dependent: $wrap_type,
+            }
+        );
 
-impl Iterator for $name {
-    type Item = $inner_type;
+        impl Iterator for $name {
+            type Item = $inner_type;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        self.with_dependent_mut(|_, objs| objs.next())
-    }
-}
-
+            fn next(&mut self) -> Option<Self::Item> {
+                self.with_dependent_mut(|_, objs| objs.next())
+            }
+        }
     };
 }
 
@@ -63,7 +65,9 @@ impl<T: Iterator> Iterator for OsmObjs<T> {
 /// Transforms a `Result<blob>` into a `Iterator<Item = Result<OsmObj>>`.
 pub fn result_blob_into_iter(result: crate::Result<Blob>) -> OsmObjs<OsmBlobObjs> {
     match result.and_then(|b| crate::reader::primitive_block_from_blob(&b)) {
-        Ok(block) => OsmObjs(OsmObjsImpl::OkIter(OsmBlobObjs::new(block, blocks::iter).map(Ok))),
+        Ok(block) => OsmObjs(OsmObjsImpl::OkIter(
+            OsmBlobObjs::new(block, blocks::iter).map(Ok),
+        )),
         Err(e) => OsmObjs(OsmObjsImpl::ErrIter(iter::once(Err(e)))),
     }
 }
@@ -71,7 +75,9 @@ pub fn result_blob_into_iter(result: crate::Result<Blob>) -> OsmObjs<OsmBlobObjs
 /// Transforms a `Result<blob>` into a `Iterator<Item = Result<Node>>`.
 pub fn result_blob_into_node_iter(result: crate::Result<Blob>) -> OsmObjs<OsmBlobNodes> {
     match result.and_then(|b| crate::reader::primitive_block_from_blob(&b)) {
-        Ok(block) => OsmObjs(OsmObjsImpl::OkIter(OsmBlobNodes::new(block, blocks::nodes).map(Ok))),
+        Ok(block) => OsmObjs(OsmObjsImpl::OkIter(
+            OsmBlobNodes::new(block, blocks::nodes).map(Ok),
+        )),
         Err(e) => OsmObjs(OsmObjsImpl::ErrIter(iter::once(Err(e)))),
     }
 }
@@ -79,7 +85,9 @@ pub fn result_blob_into_node_iter(result: crate::Result<Blob>) -> OsmObjs<OsmBlo
 /// Transforms a `Result<blob>` into a `Iterator<Item = Result<Way>>`.
 pub fn result_blob_into_way_iter(result: crate::Result<Blob>) -> OsmObjs<OsmBlobWays> {
     match result.and_then(|b| crate::reader::primitive_block_from_blob(&b)) {
-        Ok(block) => OsmObjs(OsmObjsImpl::OkIter(OsmBlobWays::new(block, blocks::ways).map(Ok))),
+        Ok(block) => OsmObjs(OsmObjsImpl::OkIter(
+            OsmBlobWays::new(block, blocks::ways).map(Ok),
+        )),
         Err(e) => OsmObjs(OsmObjsImpl::ErrIter(iter::once(Err(e)))),
     }
 }
@@ -87,7 +95,9 @@ pub fn result_blob_into_way_iter(result: crate::Result<Blob>) -> OsmObjs<OsmBlob
 /// Transforms a `Result<blob>` into a `Iterator<Item = Result<Relation>>`.
 pub fn result_blob_into_relation_iter(result: crate::Result<Blob>) -> OsmObjs<OsmBlobRelations> {
     match result.and_then(|b| crate::reader::primitive_block_from_blob(&b)) {
-        Ok(block) => OsmObjs(OsmObjsImpl::OkIter(OsmBlobRelations::new(block, blocks::relations).map(Ok))),
+        Ok(block) => OsmObjs(OsmObjsImpl::OkIter(
+            OsmBlobRelations::new(block, blocks::relations).map(Ok),
+        )),
         Err(e) => OsmObjs(OsmObjsImpl::ErrIter(iter::once(Err(e)))),
     }
 }

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -29,7 +29,7 @@ impl Tags {
 
     /// Returns if it contains a tag with the given `key` and `value`.
     pub fn contains(&self, key: &str, value: &str) -> bool {
-        self.0.get(key).map_or(false, |v| v.as_str() == value)
+        self.0.get(key).is_some_and(|v| v.as_str() == value)
     }
 
     /// Consume tags into inner FlatMap representation

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -127,10 +127,11 @@ impl<R: io::Read> OsmPbfReader<R> {
     /// CPU usage are guaranteed to be bounded even if the caller stop
     /// consuming items.
     pub fn par_iter_relations(&mut self) -> RelationParIter<'_, R> {
-        RelationParIter(self.blobs().par_flat_map(blobs::result_blob_into_relation_iter))
+        RelationParIter(
+            self.blobs()
+                .par_flat_map(blobs::result_blob_into_relation_iter),
+        )
     }
-
-
 
     /// Rewinds the pbf file to the begining.
     ///
@@ -366,7 +367,6 @@ pub_iterator_type! {
                                       fn(Result<Blob>) -> blobs::OsmObjs<blobs::OsmBlobWays>>
     where R: io::Read + 'a
 }
-
 
 pub_iterator_type! {
     #[doc="Iterator on the `OsmObj` of the pbf file."]


### PR DESCRIPTION
This PR adds [GitHub Actions](https://github.com/features/actions) CI with basic sanity checks (fmt, clippy, tests), which is [free for public repos](https://docs.github.com/en/billing/managing-billing-for-your-products/managing-billing-for-github-actions/about-billing-for-github-actions#included-storage-and-minutes).

To make them pass this PR also applies edits suggested by `cargo fmt` and `cargo clippy` - all changes are in separate commits.

An example how it works can be seen here - https://github.com/kinkard/osmpbfreader-rs/actions