### PR TITLE
chore: Remove leftover badges from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,6 @@ license = "WTFPL"
 readme = "README.md"
 edition = "2021"
 
-[badges]
-travis-ci = { repository = "TeXitoi/osmpbfreader-rs" }
-appveyor = { repository = "TeXitoi/osmpbfreader-rs" }
-
 [dependencies]
 byteorder = "1.3"
 flat_map = { version = "0.0.10", features = ["serde1"] }


### PR DESCRIPTION
Removes a leftover after https://github.com/TeXitoi/osmpbfreader-rs/pull/54